### PR TITLE
Adding Support for log4j class relocated

### DIFF
--- a/src/main/java/com/github/edwgiz/mavenShadePlugin/log4j2CacheTransformer/PluginsCacheFileTransformer.java
+++ b/src/main/java/com/github/edwgiz/mavenShadePlugin/log4j2CacheTransformer/PluginsCacheFileTransformer.java
@@ -46,7 +46,7 @@ public class PluginsCacheFileTransformer implements ResourceTransformer {
 
 
     public boolean hasTransformedResource() {
-        return tempFiles.size() > 1;
+        return tempFiles.size() >= 1;
     }
 
 

--- a/src/test/java/org/apache/logging/log4j/shadedTranformer/PluginsCacheFileTransformerTest.java
+++ b/src/test/java/org/apache/logging/log4j/shadedTranformer/PluginsCacheFileTransformerTest.java
@@ -1,18 +1,64 @@
 package org.apache.logging.log4j.shadedTranformer;
 
 import com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer;
+import org.apache.logging.log4j.core.config.plugins.processor.PluginCache;
+import org.apache.logging.log4j.core.config.plugins.processor.PluginEntry;
+import org.apache.maven.plugins.shade.relocation.Relocator;
+import org.apache.maven.plugins.shade.relocation.SimpleRelocator;
 import org.junit.Test;
 
 import java.io.InputStream;
+import java.net.URL;
+import java.util.Map;
 
+import static java.util.Collections.enumeration;
+import static java.util.Collections.singletonList;
 import static org.apache.logging.log4j.core.config.plugins.processor.PluginProcessor.PLUGIN_CACHE_FILE;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.junit.Assert.assertThat;
 
 public class PluginsCacheFileTransformerTest {
+
+    final URL pluginUrl = getClass().getClassLoader().getResource(PLUGIN_CACHE_FILE);
 
     @Test
     public void test() throws Exception {
         PluginsCacheFileTransformer t = new PluginsCacheFileTransformer();
         final InputStream is = getClass().getClassLoader().getResourceAsStream(PLUGIN_CACHE_FILE);
         t.processResource(PLUGIN_CACHE_FILE, is, null);
+    }
+
+
+    @Test
+    public void test_relocation() throws Exception {
+        PluginsCacheFileTransformer t = new PluginsCacheFileTransformer();
+        Relocator log4jRelocator = new SimpleRelocator("org.apache.logging", "new.location.org.apache.logging", null, null);
+        PluginCache aggregator = new PluginCache();
+        aggregator.loadCacheFiles(enumeration(singletonList(pluginUrl)));
+
+
+        t.relocatePlugin(aggregator, singletonList(log4jRelocator));
+
+        for (Map<String, PluginEntry> pluginEntryMap : aggregator.getAllCategories().values()) {
+            for (PluginEntry entry : pluginEntryMap.values()) {
+                assertThat(entry.getClassName(), startsWith("new.location.org.apache.logging"));
+            }
+        }
+    }
+
+    @Test
+    public void test_relocation_noMatchingRelocator() throws Exception {
+        PluginsCacheFileTransformer t = new PluginsCacheFileTransformer();
+        Relocator log4jRelocator = new SimpleRelocator("com.apache.logging", "new.location.com.apache.logging", null, null);
+        PluginCache aggregator = new PluginCache();
+        aggregator.loadCacheFiles(enumeration(singletonList(pluginUrl)));
+
+        t.relocatePlugin(aggregator, singletonList(log4jRelocator));
+
+        for (Map<String, PluginEntry> pluginEntryMap : aggregator.getAllCategories().values()) {
+            for (PluginEntry entry : pluginEntryMap.values()) {
+                assertThat(entry.getClassName(), startsWith("org.apache.logging"));
+            }
+        }
     }
 }

--- a/src/test/java/org/apache/logging/log4j/shadedTranformer/PluginsCacheFileTransformerTest.java
+++ b/src/test/java/org/apache/logging/log4j/shadedTranformer/PluginsCacheFileTransformerTest.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import static java.util.Collections.enumeration;
 import static java.util.Collections.singletonList;
 import static org.apache.logging.log4j.core.config.plugins.processor.PluginProcessor.PLUGIN_CACHE_FILE;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.assertThat;
 
@@ -26,6 +27,8 @@ public class PluginsCacheFileTransformerTest {
         PluginsCacheFileTransformer t = new PluginsCacheFileTransformer();
         final InputStream is = getClass().getClassLoader().getResourceAsStream(PLUGIN_CACHE_FILE);
         t.processResource(PLUGIN_CACHE_FILE, is, null);
+
+        assertThat(t.hasTransformedResource(), is(true));
     }
 
 


### PR DESCRIPTION
Hi, while trying to create a Fatjar used to encapsulate conflicting logging configuration with log4j and SLF4j, I came across you plugin through various post on stack overflow.  Unfortunately, it was not working because I was moving log4j2 classes somewhere else and also because I had only 1 log4jPlugins.dat in my FatJar.

I'm proposing those fixe so that It can work with the following configuration

```
<plugin>
    <groupId>org.apache.maven.plugins</groupId>
    <artifactId>maven-shade-plugin</artifactId>
    <version>2.4.1</version>
    <executions>
        <execution>
            <phase>package</phase>
            <goals>
                <goal>shade</goal>
            </goals>
            <configuration>
                <relocations>
                    <relocation>
                        <pattern>org.apache.logging</pattern> 
                        <shadedPattern>new.location.org.apache.logging</shadedPattern>
                    </relocation>
                </relocations>
                <transformers>
                    <transformer implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer">
                    </transformer>
                </transformers>
            </configuration>
        </execution>
    </executions>
    <dependencies>
        <dependency>
            <groupId>com.github.edwgiz</groupId>
            <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
            <version>2.6.1</version>
        </dependency>
    </dependencies>
</plugin>
```