### PR TITLE
Remove tempfiles from array once they're deleted

### DIFF
--- a/src/main/java/com/github/edwgiz/mavenShadePlugin/log4j2CacheTransformer/PluginsCacheFileTransformer.java
+++ b/src/main/java/com/github/edwgiz/mavenShadePlugin/log4j2CacheTransformer/PluginsCacheFileTransformer.java
@@ -62,6 +62,7 @@ public class PluginsCacheFileTransformer implements ResourceTransformer {
             for (File tempFile : tempFiles) {
                 //noinspection ResultOfMethodCallIgnored
                 tempFile.delete();
+                tempFiles.remove(tempFile);
             }
         }
     }


### PR DESCRIPTION
If shade() is going to be called multiple times (e.g. if createSourcesJar=true), then the plugin will error out when it tries to re-read the now deleted temp files. Removing the files from the array prevents modifyOutputStream from being called on subsequent invocations unless there's actually new plugin manifests to merge.